### PR TITLE
Be more specific about which version of Alex's Mobs this mod is compatible with

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -64,15 +64,13 @@ side="BOTH"
 [[dependencies.alexsmobsinteraction]]
 modId="alexsmobs"
 mandatory=true
-# This version range declares a minimum of the current minecraft version up to but not including the next major version
-versionRange="[1.22.8,)"
+versionRange="[1.22.8]"
 ordering="BEFORE"
 side="BOTH"
 
 [[dependencies.alexsmobsinteraction]]
 modId="soulfired"
 mandatory=false
-# This version range declares a minimum of the current minecraft version up to but not including the next major version
-versionRange="[3.2.1.0,)"
+versionRange="[3.2.1.0]"
 ordering="NONE"
 side="BOTH"


### PR DESCRIPTION
Improves UX when mod is incompatible instead of crashing

Instead of crashing when the mod is incompatible with a specific version of Alex's Mobs, it now shows an error screen

![image](https://github.com/user-attachments/assets/4253b133-7d81-464c-bf54-03c664786e0f)